### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+
 
 jobs:
   luacheck:
@@ -11,10 +16,7 @@ jobs:
       uses: actions/checkout@v2
     -
       name: Setup Lua
-      uses: leafo/gh-actions-lua@v9
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -28,12 +30,11 @@ jobs:
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-2.0.5"
-          - "luajit-openresty"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
     steps:
     -
       name: Checkout
@@ -42,12 +43,9 @@ jobs:
         submodules: 'true'
     -
       name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v9
+      uses: mah0x211/setup-lua@v1
       with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+        versions: ${{ matrix.lua-version }}
     -
       name: Install Tools
       run: |
@@ -61,9 +59,10 @@ jobs:
     -
       name: Run Test
       run: |
-        testcase --coverage ./test/
+        testcase ./test/
     -
-      name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      name: Upload Coverage Report
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ remove a directory.
 - `follow_symlink:boolean`: follow symbolic links. (default `false`)
 - `approver:function`: callback function to be called before removing each entry. (default `nil`)
     ```
-    -- Specification of the compiler function
+    -- Specification of the approver function
     ok [, err] = approver( entry, isdir )
 
     -- arguments

--- a/rockspecs/rmdir-scm-1.rockspec
+++ b/rockspecs/rmdir-scm-1.rockspec
@@ -15,6 +15,7 @@ dependencies = {
     "errno >= 0.4.0",
     "fstat >= 0.2.2",
     "opendir >= 0.2.1",
+    "os-remove >= 0.1.0",
 }
 build = {
     type = "builtin",


### PR DESCRIPTION
This pull request includes updates to the repository's GitHub Actions workflow, improvements to the `rmdir.lua` implementation, and adjustments to dependencies in the `rockspec` file. The changes focus on enhancing functionality, improving maintainability, and updating dependencies.

### GitHub Actions Workflow Updates:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-R8): Modified the `push` trigger to ignore changes to markdown files and the `LICENSE` file. Updated the Lua setup action to use `mah0x211/setup-lua@v1`. Changed the strategy matrix to specify latest versions of Lua and LuaJIT. Updated Codecov action to version 4 and added support for a token from secrets. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-R8) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R19) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L31-R37) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L45-R48) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L66-R67)

### `rmdir.lua` Implementation Improvements:
* [`rmdir.lua`](diffhunk://#diff-12df5d165752dc8fc1cd88e937b355ec2a19eb6d831726708e61e10fab2ecfc3L26-R31): Replaced direct use of `os.remove` with `require('os.remove')` for modularity. Added helper functions `isdir` to check directory existence and `rment` to handle entry removal with approver logic. Refactored `removedir` to streamline recursive directory removal and error handling. Improved parameter handling in `rmdir` for better flexibility and code readability. [[1]](diffhunk://#diff-12df5d165752dc8fc1cd88e937b355ec2a19eb6d831726708e61e10fab2ecfc3L26-R31) [[2]](diffhunk://#diff-12df5d165752dc8fc1cd88e937b355ec2a19eb6d831726708e61e10fab2ecfc3R48-R77) [[3]](diffhunk://#diff-12df5d165752dc8fc1cd88e937b355ec2a19eb6d831726708e61e10fab2ecfc3L59-R118) [[4]](diffhunk://#diff-12df5d165752dc8fc1cd88e937b355ec2a19eb6d831726708e61e10fab2ecfc3L105-R136) [[5]](diffhunk://#diff-12df5d165752dc8fc1cd88e937b355ec2a19eb6d831726708e61e10fab2ecfc3R151-R163)

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31): Corrected the description of the `approver` function specification for clarity.

### Dependency Adjustments:
* [`rockspecs/rmdir-scm-1.rockspec`](diffhunk://#diff-b7a6f8c501df8d2fac79bbe902112c8d799abafd078be96e57d1be4d81fcaf95R18): Added `os-remove >= 0.1.0` as a dependency to reflect the modularization of `os.remove`.